### PR TITLE
Validate: Allow sentences that start with "Fixes" or "Closes"

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -46,7 +46,8 @@ module.exports = function( message, options ) {
 		}
 		// ticket references
 		if ( /^(close[sd]?|fix(e(sd)?)?|resolve[sd]?)/i.test( line ) ) {
-			if ( !/(Fixes|Closes) (.*#|gh-)[0-9]+/.test( line )) {
+			if ( !/^(Fixes|Closes)\s+[^\s\d]+(\s|$)/.test( line ) &&
+					!/^(Fixes|Closes) (.*#|gh-)[0-9]+/.test( line ) ) {
 				errors.push( "Invalid ticket reference, must be " +
 					"/(Fixes|Closes) (.*#|gh-)[0-9]+/, was: " + line );
 			}

--- a/test.js
+++ b/test.js
@@ -49,6 +49,13 @@ var valid = [
 	},
 	{
 		msg: "Component: Message\n#comment"
+	},
+	{
+		msg: "Component: short message\n" +
+		"\n" +
+		"Fixes some bug.\n" +
+		"\n" +
+		"Fixes #123"
 	}
 ];
 


### PR DESCRIPTION
The idea is to allow "Fixes" or "Closes" followed by space(s) followed by a word that doesn't contain numbers.
