### PR TITLE
Validate: Stop validation at first comment, supports verbose output

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -13,10 +13,15 @@ module.exports = function( message, options ) {
 
 	var errors = [];
 
-	message.split(/\n/).forEach(function ( line, index ) {
-		// Skip comments
+	// Can't cancel forEach, so abuse every to stop at first comment
+	message.split( /\n/ ).every(function( line, index ) {
+		// Stop at scissor line to support the verbose option
+		if ( line === "# ------------------------ >8 ------------------------" ) {
+			return false;
+		}
+		// Ignore comments
 		if ( /^#/.test( line ) ) {
-			return;
+			return true;
 		}
 		if ( index === 0 ) {
 			// Allow tag commits
@@ -56,6 +61,7 @@ module.exports = function( message, options ) {
 					"/(Fixes|Closes) (.*#|gh-)[0-9]+/, was: " + line );
 			}
 		}
+		return true;
 	});
 
 	return errors;

--- a/test.js
+++ b/test.js
@@ -39,7 +39,15 @@ var valid = [
 		msg: "Component: short message\n" +
 		"\n" +
 		"# Long comment that has to be ignored line too long beyond 72 chars line too long beyond" +
-			"line too long line too long line too long"
+			"line too long line too long line too long\n" +
+		"# ------------------------ >8 ------------------------\n" +
+		"# Do not touch the line above.\n" +
+		"# Everything below will be removed.\n" +
+		"diff --git a/test.js b/test.js\n" +
+		"index 36978ce..8edf326 100644\n" +
+		"diff --git a/foo b/foo\n" +
+		"-	\n" +
+		"+	}, mment that has to be ignored line too long beyond 72 chars line too long beyond"
 	},
 	{
 		msg: "v1.13.0"
@@ -107,6 +115,11 @@ var invalid = [
 	{
 		msg: "Bla: blub\n\nResolving xy-9991",
 		expected: [ "Invalid ticket reference, must be /(Fixes|Closes) (.*#|gh-)[0-9]+/, was: Resolving xy-9991" ]
+	},
+	{
+		msg: "bla: blu\n\n# comment\nResolving xy12312312312"
+		,
+		expected: [ "Invalid ticket reference, must be /(Fixes|Closes) (.*#|gh-)[0-9]+/, was: Resolving xy12312312312" ]
 	}
 ];
 


### PR DESCRIPTION
This causes the validation to accept anything after the first comment line,
which might cause more problems later. I don't see a better way to support
the --verbose option, since there is no delimiter or even indication that the
option is in use.

Fixes #15 

Ping @markelog - what do you think? Is that worth the trouble?
