### PR TITLE
Validate: Add check for empty commit subject line

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -32,6 +32,9 @@ module.exports = function( message, options ) {
 			if ( /^Merge branch/.test( line ) ) {
 				return;
 			}
+			if ( 0 === line.length ) {
+				errors.push( "First line (subject) must not be empty" );
+			}
 			if ( line.length > options.limits.subject ) {
 				errors.push( "First line (subject) must be no longer than " +
 					options.limits.subject + " characters" );

--- a/test.js
+++ b/test.js
@@ -80,6 +80,17 @@ var valid = [
 
 var invalid = [
 	{
+		msg: "",
+		expected: [ "First line (subject) must not be empty" ],
+		options: {
+			component: false
+		}
+	},
+	{
+		msg: "",
+		expected: [ "First line (subject) must not be empty", "First line (subject) must indicate the component", "First line (subject) must have a message after the component" ]
+	},
+	{
 		msg: "Component: short message but actually a little bit over default character limit",
 		expected: [ "First line (subject) must be no longer than 72 characters" ]
 	},


### PR DESCRIPTION
Git aborts the commit if an empty message is passed, but since we can throw an error, I've added support for this for consistency.
