### PR TITLE
Allow "Merge <sha> into <sha>"

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -23,7 +23,7 @@ module.exports = function( message, options ) {
 				return;
 			}
 			// Allow merge commits
-			if ( /^Merge branch/.test( line ) ) {
+			if ( /^Merge branch/.test( line ) || /^Merge [0-9a-f]+ into [0-9a-f]+/.test( line ) ) {
 				return;
 			}
 			if ( 0 === line.length ) {

--- a/test.js
+++ b/test.js
@@ -94,6 +94,9 @@ var valid = [
 		msg: "Merge branch 'one' into two"
 	},
 	{
+		msg: "Merge e8d808b into f040453"
+	},
+	{
 		msg: "fixup! for git to squash",
 		options: testComponent
 	},


### PR DESCRIPTION
Given merge commits are allowed, this change extends it by including github flavor: "Merge \<sha\> into \<sha\>", which is found on automatic PR merges, e.g., https://github.com/jquery/globalize/commit/8777835de81ec83699dcbfbda1eefe5677907579.