### PR TITLE
Add several real commit messages from jQuery Core that pass validation

### DIFF
--- a/test.js
+++ b/test.js
@@ -121,6 +121,64 @@ var valid = [
 	},
 	{
 		msg: "fixedToolbar: Prevent resize"
+	},
+	{
+		msg: "Docs:Tests: Remove legacy code & add support comments where needed\n" +
+			 "\n" +
+			 "This commits backports some changes done in the patch to the then-existing\n" +
+			 "compat branch that removed support for old browsers and added some support\n" +
+			 "comments.\n" +
+			 "\n" +
+			 "Refs 90d7cc1d8b2ea7ac75f0eacb42439349c9c73278"
+	},
+	{
+		msg: "Support: improve support properties computation\n" +
+			 "\n" +
+			 "* Remove div from the memory if it is not needed anymore\n" +
+			 "\n" +
+			 "* Make `computeStyleTests` method a singleton\n" +
+			 "\n" +
+			 "Fixes gh-3018 Closes gh-3021"
+	},
+	{
+		msg: "Tests: add additional test for jQuery.isPlainObject\n" +
+			 "\n" +
+			 "Ref 00575d4d8c7421c5119f181009374ff2e7736127\n" +
+			 "Also see discussion in\n" +
+			 "https://github.com/jquery/jquery/pull/2970#discussion_r54970557"
+	},
+	{
+		msg: 'Revert "Offset: account for scroll when calculating position"\n' +
+			 "\n" +
+			 "This reverts commit 2d715940b9b6fdeed005cd006c8bf63951cf7fb2.\n" +
+			 "This commit provoked new issues: gh-2836, gh-2828.\n" +
+			 "At the meeting, we decided to revert offending commit\n" +
+			 "(in all three branches - 2.2-stable, 1.12-stable and master)\n" +
+			 "and tackle this issue in 3.x.\n" +
+			 "\n" +
+			 "Fixes gh-2828"
+	},
+	{
+		msg: 'Revert "Attributes: Remove undocumented .toggleClass( boolean ) signature"\n' +
+			 "\n" +
+			 "This reverts commit 53f798cf4d783bb813b4d1ba97411bc752b275f3.\n" +
+			 "\n" +
+			 "- Turns out this is documented, even if not fully. Need to deprecate before removal.",
+		options: {
+			limits: {
+				subject: 90,
+				other: 90
+			}
+		}
+	},
+	{
+		msg: "Event: Separate trigger/simulate into its own module\n" +
+			 "\n" +
+			 "Fixes gh-1864\n" +
+			 "Closes gh-2692\n" +
+			 "\n" +
+			 "This also pulls the focusin/out special event into its own module, since that\n" +
+			 "depends on simulate(). NB: The ajax module triggers events pretty heavily."
 	}
 ];
 


### PR DESCRIPTION
Each commit message is interesting in some ways:
 * ComponentA:ComponentB: syntax in header line
 * Long Description spans several paragraphs.
 * Long Description is mixed with ticket referencing
 * Revert commit messages: 'Revert "Component: subject"'

It is my plan to create my next pull request with test cases from [validate-commit-msg.spec.js](https://github.com/angular/angular.js/blob/c1eaf3480b9a88e5309ff4931a720f3f62bd7606/validate-commit-msg.spec.js). It might not work right now, I will just see.

I am also looking at the way dmethvin [was refactoring](https://github.com/dmethvin/commitplease/commit/8c5dc99d74fcdb823d23a7ffd1dda7bf3eba515b) the regular expressions (currently they are not DRY).

Would you like to use a testing framework? If yes -- which one, if no -- a quick reason why? 