### PR TITLE
Validate: move regexes (that detect ticket references) into default options

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ Options and their defaults:
 ```js
 component: true,
 components: [],
+markerPattern: '^(clos|fix|resolv)(e[sd]|ing)',
+actionPattern: '^([Cc]los|[Ff]ix|[Rr]esolv)(e[sd]|ing)\\s+[^\\s\\d]+(\\s|$)',
+ticketPattern: '^(Closes|Fixes) (.*#|gh-|[A-Z]{2,}-)[0-9]+',
 limits: {
 	subject: 72,
 	other: 80
@@ -50,6 +53,15 @@ limits: {
 * `component`: The default `true` requires a component, set to `false` to skip the check.
 * `components`: A list of valid components. When a component is found, it's compared to the ones specified in this array.
 * `limits`: Line length limits, for subject and other lines.
+
+The following options are experimental and are subject to change:
+* `markerPattern`: A (intentionally loose) RegExp that indicates that the line might be a ticket reference. Is caseinsensitive.
+* `actionPattern`: A RegExp that makes a line marked by `markerPattern` valid even if the line does not fit `ticketPattern`
+* `ticketPattern`: A RegExp that detects ticket references: Closes gh-1, Fixes gh-42, WEB-451 and similar.
+
+The ticket reference match will fail only if `markerPattern` succeeds and __both__ `ticketPattern` and `actionPattern` fail.
+
+When overwriting these patterns in `package.json`, remember to escape special characters.
 
 ### Customizing the bundled options
 

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -2,12 +2,15 @@ var merge = require('mout/object/merge')
 var semver = require('semver')
 var subjectExceptions = /^(fixup|squash)!|^\[[^\]]+\]:/
 var defaults = {
-    component: true,
-    components: [],
-    limits: {
-      subject: 72,
-      other: 80
-    }
+  component: true,
+  components: [],
+  markerPattern: '^(clos|fix|resolv)(e[sd]|ing)',
+  actionPattern: '^([Cc]los|[Ff]ix|[Rr]esolv)(e[sd]|ing)\\s+[^\\s\\d]+(\\s|$)',
+  ticketPattern: '^(Closes|Fixes) (.*#|gh-|[A-Z]{2,}-)[0-9]+',
+  limits: {
+    subject: 72,
+    other: 80
+  }
 }
 
 module.exports = function (message, options) {
@@ -59,12 +62,15 @@ module.exports = function (message, options) {
         ' allowed. Was: ' + line.substring(0, 20) + '[...]')
     }
 
+    var markerPattern = new RegExp(options.markerPattern, 'i')
+    var actionPattern = new RegExp(options.actionPattern)
+    var ticketPattern = new RegExp(options.ticketPattern)
+
     // Ticket references
-    if (index > 0 && /^(clos|fix|resolv)(e[sd]|ing)/i.test(line)) {
-      if (!/^(Fixes|Closes)\s+[^\s\d]+(\s|$)/.test(line) &&
-        !/^(Fixes|Closes) (.*#|gh-|[A-Z]{2,}-)[0-9]+/.test(line)) {
+    if (index > 0 && markerPattern.test(line)) {
+      if (!actionPattern.test(line) && !ticketPattern.test(line)) {
         errors.push('Invalid ticket reference, must be ' +
-          '/(Fixes|Closes) (.*#|gh-|[A-Z]{2,}-)[0-9]+/, was: ' + line)
+          ticketPattern + ', was: ' + line)
       }
     }
     return true
@@ -72,3 +78,5 @@ module.exports = function (message, options) {
 
   return errors
 }
+
+module.exports.defaults = defaults

--- a/test.js
+++ b/test.js
@@ -85,6 +85,13 @@ var valid = [
   },
   {
     msg: 'Component: short message\n' +
+         '\n' +
+         'Resolves some issue.\n' +
+         '\n' +
+         'Fixes #123'
+  },
+  {
+    msg: 'Component: short message\n' +
       '\n' +
       'Fix some bug.\n' +
       '\n' +
@@ -96,6 +103,11 @@ var valid = [
       'Fix some bug.\n' +
       '\n' +
       'Fixes WEB-1093'
+  },
+  {
+    msg: 'Component: short message\n' +
+         '\n' +
+         'Fixes CRM-322'
   },
   {
     msg: "Merge branch 'one' into two"
@@ -173,14 +185,16 @@ var valid = [
   },
   {
     msg: 'Event: Separate trigger/simulate into its own module\n' +
-      '\n' +
-      'Fixes gh-1864\n' +
-      'Closes gh-2692\n' +
-      '\n' +
-      'This also pulls the focusin/out special event into its own module, since that\n' +
-      'depends on simulate(). NB: The ajax module triggers events pretty heavily.'
+         '\n' +
+         'Fixes gh-1864\n' +
+         'Closes gh-2692\n' +
+         '\n' +
+         'This also pulls the focusin/out special event into its own module, since that\n' +
+         'depends on simulate(). NB: The ajax module triggers events pretty heavily.'
   }
 ]
+
+var ticketPattern = new RegExp(validate.defaults.ticketPattern)
 
 var invalid = [
   {
@@ -228,24 +242,30 @@ var invalid = [
   },
   {
     msg: 'Docs: Fix a typo\n\nCloses: gh-155',
-    expected: [ 'Invalid ticket reference, must be /(Fixes|Closes) (.*#|gh-|[A-Z]{2,}-)[0-9]+/, was: Closes: gh-155' ]
+    expected: [ 'Invalid ticket reference, must be ' + ticketPattern + ', was: Closes: gh-155' ]
   },
   {
     msg: 'Bla: blub\n\nClosing #1',
-    expected: [ 'Invalid ticket reference, must be /(Fixes|Closes) (.*#|gh-|[A-Z]{2,}-)[0-9]+/, was: Closing #1' ]
+    expected: [ 'Invalid ticket reference, must be ' + ticketPattern + ', was: Closing #1' ]
   },
   {
     msg: 'Bla: blub\n\nFixing gh-1',
-    expected: [ 'Invalid ticket reference, must be /(Fixes|Closes) (.*#|gh-|[A-Z]{2,}-)[0-9]+/, was: Fixing gh-1' ]
+    expected: [ 'Invalid ticket reference, must be ' + ticketPattern + ', was: Fixing gh-1' ]
   },
   {
     msg: 'Bla: blub\n\nResolving xy-9991',
-    expected: [ 'Invalid ticket reference, must be /(Fixes|Closes) (.*#|gh-|[A-Z]{2,}-)[0-9]+/, was: Resolving xy-9991' ]
+    expected: [ 'Invalid ticket reference, must be ' + ticketPattern + ', was: Resolving xy-9991' ]
   },
   {
     msg: 'bla: blu\n\n# comment\nResolving xy12312312312',
-    expected: [ 'Invalid ticket reference, must be /(Fixes|Closes) (.*#|gh-|[A-Z]{2,}-)[0-9]+/,' +
-    ' was: Resolving xy12312312312' ]
+    expected: [ 'Invalid ticket reference, must be ' + ticketPattern + ', was: Resolving xy12312312312' ]
+  },
+  {
+    msg: 'Component: short message\n\nFixes #123',
+    options: {
+      ticketPattern: /^(Closes|Fixes) ([A-Z]{2,}-)[0-9]+/
+    },
+    expected: [ 'Invalid ticket reference, must be ' + '/^(Closes|Fixes) ([A-Z]{2,}-)[0-9]+/' + ', was: Fixes #123' ]
   }
 ]
 


### PR DESCRIPTION
This is basically what @dmethvin was doing [in his repo](https://github.com/dmethvin/commitplease/commit/8c5dc99d74fcdb823d23a7ffd1dda7bf3eba515b?diff=split). I did this because it improves my understanding of how commitplease handles ticket references before I go and solve #33 and #34.

The important bit: it is my understanding that there is currently a bug in commitplease. Just copy the single test that has been added by this PR into current version of commitplease and see for yourself.

Secondly, I ditched the "makeRegExp" funtion that dmethvin was developing. It is my beief that it somehow subtly changes the `actionPattern` regex but I was not able to pinpoint the problem.

Finally, I would like to ask questions:

1. In its current form in commitplease (and in this PR) ticket references are *very* rigid. I mean, if you write this commit message: "Component: did some work, close #422", commitplease will not be checking this "close #422" part at all. It will also not check any references inside a line of text. Is this intentional? 

2. Am I right that [this original regex](https://github.com/jzaefferer/commitplease/blob/212aaca1e8022d087adccada0d775eaa690b5e76/lib/validate.js#L64) is supposed to accept lines which simply happen to start with "Fixes some stuff" or "Closes the issue of whatever"? If so, it is my belief that it should be more loose, like the `actionPattern` in this PR. I don't know why it is called `actionPattern`, it is how dmethvin called it :)
  