### PR TITLE
Hook: get message from .git/COMMIT_EDITMSG instead of console

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,19 @@ In addition, you can specify the `nohook` option as something truthy, which prev
 }
 ```
 
+When using commitplease together with [husky](https://github.com/typicode/husky), the following configuration will let husky manage all the hooks and trigger commitplease as well:
+
+```json
+{
+  "scripts": {
+    "commitmsg": "node node_modules/commitplease"
+  }
+  "commitplease": {
+    "nohook": true
+  }
+}
+```
+
 ## License
 Copyright Jörn Zaefferer  
 Released under the terms of the MIT license.

--- a/README.md
+++ b/README.md
@@ -100,13 +100,15 @@ When using commitplease together with [husky](https://github.com/typicode/husky)
 ```json
 {
   "scripts": {
-    "commitmsg": "node node_modules/commitplease"
-  }
+    "commitmsg": "commitplease"
+  },
   "commitplease": {
     "nohook": true
   }
 }
 ```
+
+However, since husky does not use npm in silent mode (and there is [no easy way](https://github.com/typicode/husky/pull/47) to make it [do so](https://github.com/npm/npm/issues/5452)), there will be a lot of additional output when a message fails validation. Therefore, using commitplease alone is recommended.
 
 ## License
 Copyright Jörn Zaefferer  

--- a/commit-msg-hook.js
+++ b/commit-msg-hook.js
@@ -1,4 +1,4 @@
 #!/usr/bin/env node
 
 // `commitplease-original`
-require('commitplease')(process.argv[ 2 ])
+require('commitplease')

--- a/index.js
+++ b/index.js
@@ -7,8 +7,9 @@ var sanitize = require('./lib/sanitize')
 var options = fs.existsSync(path.join(root, 'package.json')) &&
   require(path.join(root, 'package.json')).commitplease || {}
 
-module.exports = function (messageFile) {
-  var message = sanitize(fs.readFileSync(messageFile).toString())
+;(function () {
+  var messageFile = path.resolve(process.cwd(), '.git/COMMIT_EDITMSG')
+  var message = sanitize(fs.readFileSync(messageFile, 'utf8').toString())
   var errors = validate(message, options)
   if (errors.length) {
     console.error('Invalid commit message, please fix the following issues:\n')
@@ -19,4 +20,4 @@ module.exports = function (messageFile) {
     console.error(chalk.green(message))
     process.exit(1)
   }
-}
+}())

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.3.1",
   "description": "Validates strings as commit messages",
   "main": "index.js",
+  "bin": {"commitplease": "./commit-msg-hook.js"},
   "scripts": {
     "install": "node install",
     "uninstall": "node uninstall",


### PR DESCRIPTION
This pull request is all about making commitplease and husky work together.

Turns out, typicode/husky#30 already attempted to add command line arguments to hooks and it did not work out. So, I decided to modify commitplease instead and made the hook:
  
  1. not care if it is a `./git/commit-msg` or a `node_modules/commitplease/commit-msg-hook.js`
  2. get the commit message from `.git/COMMIT_EDITMSG`

The idea is that the user adds this husky line under "scripts" in the package.json:
```
"commitmsg": "--silent node node_modules/commitplease/commit-msg-hook.js"
```
Then they run `npm install` and actually don't care who creates the hook first. If husky does, then that line from package.json will run commitplease and if commitplease does, then it runs as usual.

The bad thing is this extra configuration bit. Moreover, it is too long. I wanted to make it at least something like:
```
"commitmsg": "--silent node commitplease"
```
but failed :( For it to work, it looks like I need to change  `"main" : "index.js"` to `"main" : "commit-msg-hook.js"` and do something else too.