### PR TITLE
Change test logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,13 @@
   "version": "2.3.1",
   "description": "Validates strings as commit messages",
   "main": "index.js",
-  "bin": {"commitplease": "./commit-msg-hook.js"},
+  "bin": {
+    "commitplease": "./commit-msg-hook.js"
+  },
   "scripts": {
     "install": "node install",
     "uninstall": "node uninstall",
-    "test": "standard && nodeunit test.js",
+    "test": "standard && babel-node --presets=es2015 -- node_modules/.bin/nodeunit test.js",
     "test-watch": "nodemon --exec npm run --silent test"
   },
   "repository": {
@@ -25,6 +27,9 @@
   },
   "license": "MIT",
   "devDependencies": {
+    "babel-cli": "^6.10.1",
+    "babel-preset-es2015": "^6.9.0",
+    "babel-register": "^6.9.0",
     "mout": "^0.12.0",
     "nodemon": "^1.9.1",
     "nodeunit": "^0.9.1",

--- a/test.js
+++ b/test.js
@@ -77,37 +77,51 @@ var valid = [
   },
   {
     msg: 'Component: short message\n' +
-      '\n' +
-      'Fixes some bug.\n' +
-      'Fix some other bug.\n' +
-      '\n' +
-      'Fixes #123'
+         '\n' +
+         'Fixes some bug.\n' +
+         'Fix some other bug.\n' +
+         'And fix these bugs too.\n' +
+         'And fixes other bugs too.\n'
   },
   {
     msg: 'Component: short message\n' +
          '\n' +
          'Resolves some issue.\n' +
+         'Resolve some other issue.\n' +
+         'And resolve these issues too.\n' +
+         'And resolves some other issues too.\n'
+  },
+  {
+    msg: 'Component: short message\n' +
          '\n' +
+         'Closes some issue.\n' +
+         'Close some other issue.\n' +
+         'And close these issues too.\n' +
+         'And closes some other issues too.'
+  },
+  {
+    msg: 'Component: short message\n' +
+         '\n' +
+         'Fixes #1\n' +
          'Fixes #123'
   },
   {
     msg: 'Component: short message\n' +
-      '\n' +
-      'Fix some bug.\n' +
-      '\n' +
-      'Fixes #123'
-  },
-  {
-    msg: 'Component: short message\n' +
-      '\n' +
-      'Fix some bug.\n' +
-      '\n' +
-      'Fixes WEB-1093'
+         '\n' +
+         'Fixes gh-1\n' +
+         'Fixes gh-123'
   },
   {
     msg: 'Component: short message\n' +
          '\n' +
-         'Fixes CRM-322'
+         'Fixes WEB-1\n' +
+         'Fixes WEB-123'
+  },
+  {
+    msg: 'Component: short message\n' +
+         '\n' +
+         'Fixes CRM-1\n' +
+         'Fixes CRM-123'
   },
   {
     msg: "Merge branch 'one' into two"
@@ -136,46 +150,46 @@ var valid = [
   },
   {
     msg: 'Docs:Tests: Remove legacy code & add support comments where needed\n' +
-      '\n' +
-      'This commits backports some changes done in the patch to the then-existing\n' +
-      'compat branch that removed support for old browsers and added some support\n' +
-      'comments.\n' +
-      '\n' +
-      'Refs 90d7cc1d8b2ea7ac75f0eacb42439349c9c73278'
+         '\n' +
+         'This commits backports some changes done in the patch to the then-existing\n' +
+         'compat branch that removed support for old browsers and added some support\n' +
+         'comments.\n' +
+         '\n' +
+         'Refs 90d7cc1d8b2ea7ac75f0eacb42439349c9c73278'
   },
   {
     msg: 'Support: improve support properties computation\n' +
-      '\n' +
-      '* Remove div from the memory if it is not needed anymore\n' +
-      '\n' +
-      '* Make `computeStyleTests` method a singleton\n' +
-      '\n' +
-      'Fixes gh-3018 Closes gh-3021'
+         '\n' +
+         '* Remove div from the memory if it is not needed anymore\n' +
+         '\n' +
+         '* Make `computeStyleTests` method a singleton\n' +
+         '\n' +
+         'Fixes gh-3018 Closes gh-3021'
   },
   {
     msg: 'Tests: add additional test for jQuery.isPlainObject\n' +
-      '\n' +
-      'Ref 00575d4d8c7421c5119f181009374ff2e7736127\n' +
-      'Also see discussion in\n' +
-      'https://github.com/jquery/jquery/pull/2970#discussion_r54970557'
+         '\n' +
+         'Ref 00575d4d8c7421c5119f181009374ff2e7736127\n' +
+         'Also see discussion in\n' +
+         'https://github.com/jquery/jquery/pull/2970#discussion_r54970557'
   },
   {
     msg: 'Revert "Offset: account for scroll when calculating position"\n' +
-      '\n' +
-      'This reverts commit 2d715940b9b6fdeed005cd006c8bf63951cf7fb2.\n' +
-      'This commit provoked new issues: gh-2836, gh-2828.\n' +
-      'At the meeting, we decided to revert offending commit\n' +
-      '(in all three branches - 2.2-stable, 1.12-stable and master)\n' +
-      'and tackle this issue in 3.x.\n' +
-      '\n' +
-      'Fixes gh-2828'
+         '\n' +
+         'This reverts commit 2d715940b9b6fdeed005cd006c8bf63951cf7fb2.\n' +
+         'This commit provoked new issues: gh-2836, gh-2828.\n' +
+         'At the meeting, we decided to revert offending commit\n' +
+         '(in all three branches - 2.2-stable, 1.12-stable and master)\n' +
+         'and tackle this issue in 3.x.\n' +
+         '\n' +
+         'Fixes gh-2828'
   },
   {
     msg: 'Revert "Attributes: Remove undocumented .toggleClass( boolean ) signature"\n' +
-      '\n' +
-      'This reverts commit 53f798cf4d783bb813b4d1ba97411bc752b275f3.\n' +
-      '\n' +
-      '- Turns out this is documented, even if not fully. Need to deprecate before removal.',
+         '\n' +
+         'This reverts commit 53f798cf4d783bb813b4d1ba97411bc752b275f3.\n' +
+         '\n' +
+         '- Turns out this is documented, even if not fully. Need to deprecate before removal.',
     options: {
       limits: {
         subject: 90,

--- a/test.js
+++ b/test.js
@@ -454,78 +454,78 @@ exports.tests = function (test) {
 }
 
 function testGroup (test, group) {
-  var [profiles, messages] = [group[0], group[1]]
+  let [profiles, messages] = [group[0], group[1]]
 
-  for (var profile of profiles) {
-    for (var message of messages) {
-      var excludes = message.excludes
+  for (let profile of profiles) {
+    for (let message of messages) {
+      let excludes = message.excludes
       if (excludes && excludes.indexOf(profile) !== -1) {
         continue
       }
 
-      var msg = message.msg
+      let msg = message.msg
 
-      var accepts = message.accepts
+      let accepts = message.accepts
       if (accepts && accepts.indexOf(profile) !== -1) {
-        var result = validate(sanitize(msg), profile)
+        let result = validate(sanitize(msg), profile)
         test.deepEqual(result, [], '\n' + msg)
 
         continue
       }
 
-      var rejects = message.rejects
+      let rejects = message.rejects
       if (rejects && rejects.indexOf(profile) !== -1) {
-        var result = validate(sanitize(msg), profile)
+        let result = validate(sanitize(msg), profile)
         test.notDeepEqual(result, [], '\n' + msg)
 
         continue
       }
 
-      var reasons = message.reasons
+      let reasons = message.reasons
       if (reasons && reasons.get(profile)) {
-        var reason = reasons.get(profile)
+        let reason = reasons.get(profile)
 
-        var result = validate(sanitize(msg), profile)
+        let result = validate(sanitize(msg), profile)
         test.deepEqual(result, reason, '\n' + msg)
 
         continue
       }
 
       // assume default: profile must pass the test
-      var result = validate(sanitize(msg), profile)
+      let result = validate(sanitize(msg), profile)
       test.deepEqual(result, [], '\n' + msg)
     }
   }
 
-  for (var message of messages) {
-    var msg = message.msg
+  for (let message of messages) {
+    let msg = message.msg
 
-    var accepts = message.accepts
+    let accepts = message.accepts
     if (accepts) {
-      for (var profile of accepts) {
+      for (let profile of accepts) {
         if (profiles.indexOf(profile) === -1) {
-          var result = validate(sanitize(msg), profile)
+          let result = validate(sanitize(msg), profile)
           test.deepEqual(result, [], '\n' + msg)
         }
       }
     }
 
-    var rejects = message.rejects
+    let rejects = message.rejects
     if (rejects) {
-      for (var profile of rejects) {
+      for (let profile of rejects) {
         if (profiles.indexOf(profile) === -1) {
-          var result = validate(sanitize(msg), profile)
+          let result = validate(sanitize(msg), profile)
           test.notDeepEqual(result, [], '\n' + msg)
         }
       }
     }
 
-    var reasons = message.reasons
+    let reasons = message.reasons
     if (reasons) {
-      for (var key2val of reasons) {
-        var [profile, reason] = [key2val[0], key2val[1]]
+      for (let key2val of reasons) {
+        let [profile, reason] = [key2val[0], key2val[1]]
         if (profiles.indexOf(profile) === -1) {
-          var result = validate(sanitize(msg), profile)
+          let result = validate(sanitize(msg), profile)
           test.deepEqual(result, reason, '\n' + msg)
         }
       }

--- a/test.js
+++ b/test.js
@@ -1,306 +1,534 @@
+var merge = require('mout/object/merge')
 var validate = require('./lib/validate')
 var sanitize = require('./lib/sanitize')
 
-var messageWithMultipleLines = 'Component: short message\n' +
-  '\n' +
-  'Long description'
+var profile0 = validate.defaults
+var profile1 = merge(validate.defaults, {component: false})
+var profile2 = merge(validate.defaults, {components: ['Build', 'Legacy']})
 
-var messageWithDiff = 'Component: short message\n' +
-  '\n' +
-  'some text\n' +
-  '# Long comment that has to be ignored line too long beyond 72 chars line too long beyond' +
-  'line too long line too long line too long\n' +
-  'more text\n' +
-  '# ------------------------ >8 ------------------------\n' +
-  '# Do not touch the line above.\n' +
-  '# Everything below will be removed.\n' +
-  'diff --git a/test.js b/test.js\n' +
-  'index 36978ce..8edf326 100644\n' +
-  'diff --git a/foo b/foo\n' +
-  '-	\n' +
-  '+	}, mment that has to be ignored line too long beyond 72 chars line too long beyond'
+var profile3 = merge(
+  validate.defaults, {
+    ticketPattern: '^(Closes|Fixes) ([a-zA-Z]{2,}-)[0-9]+'
+  }
+)
 
-var testComponent = {
-  components: [ 'Test' ]
-}
+var profiles0 = [profile0, profile1, profile3]
 
-var valid = [
+var messages0 = [
   {
     msg: 'Component: short message'
   },
   {
-    msg: messageWithMultipleLines
+    msg: 'Component: short message\n\n' +
+         'Long description'
+  },
+  {
+    msg: 'Component: short message\n\n' +
+         'Long description\n\n' +
+         'That spans many paragraphs'
   },
   {
     msg: 'Component: short message\n' +
-      '\n' +
-      'Long description\n' +
-      '\n' +
-      'Closes #123'
+         '#comment'
   },
   {
     msg: 'Component: short message\n' +
-      '\n' +
-      'Closes jquery/jquery-mobile#123'
+         '# comment'
   },
   {
-    msg: 'short message',
-    options: {
-      component: false
-    }
+    msg: 'Component: short message\n' +
+         '#                  comment'
+  },
+  {
+    msg: 'Component: short message\n' +
+         'text on next line',
+    reasons: new Map([
+      [profile0, [ 'Second line must always be empty' ]],
+      [profile1, [ 'Second line must always be empty' ]],
+      [profile3, [ 'Second line must always be empty' ]]
+    ])
+  },
+  {
+    msg: 'No component here, short message',
+    accepts: [profile1],
+    reasons: new Map([
+      [profile0, ['First line (subject) must indicate the component']],
+      [profile3, ['First line (subject) must indicate the component']]
+    ])
+  },
+  {
+    msg: 'Build: short message',
+    accepts: [profile2]
   },
   {
     msg: 'Test: short message',
-    options: {
-      components: [ 'Test' ]
-    }
-  },
-  {
-    msg: 'Component: message over default of 50 but below limit off 70',
-    options: {
-      limits: {
-        subject: 70
-      }
-    }
-  },
-  {
-    msg: messageWithDiff
-  },
-  {
-    msg: 'v1.13.0'
-  },
-  {
-    msg: '0.0.1'
-  },
-  {
-    msg: 'Component: Message\n#comment'
+    reasons: new Map([
+      [profile2, ["Component invalid, was 'Test', must be one of these: Build, Legacy"]]
+    ])
   },
   {
     msg: 'Component: short message\n' +
-         '\n' +
+         '# Long comments still have to be ignored' +
+         'even though they are longer than 72 characters' +
+         'notice the absense of newline character in test'
+  },
+  {
+    msg: 'Component: short message but actually a little bit over default character limit',
+    reasons: new Map([
+      [profile0, [ 'First line (subject) must be no longer than 72 characters' ]],
+      [profile1, [ 'First line (subject) must be no longer than 72 characters' ]],
+      [profile2, [
+        'First line (subject) must be no longer than 72 characters',
+        "Component invalid, was 'Component', must be one of these: Build, Legacy"
+      ]],
+      [profile3, [ 'First line (subject) must be no longer than 72 characters' ]]
+    ])
+  },
+  {
+    msg: 'Component: short message\n\n' +
+         'Long description is way past the 80 characters limit' +
+         'Long description is way past the 80 characters limit',
+    reasons: new Map([
+      [profile0, [ 'Commit message line 3 too long: 104 characters, only 80 allowed. Was: Long description is [...]' ]],
+      [profile1, [ 'Commit message line 3 too long: 104 characters, only 80 allowed. Was: Long description is [...]' ]],
+      [profile3, [ 'Commit message line 3 too long: 104 characters, only 80 allowed. Was: Long description is [...]' ]]
+    ])
+  },
+  {
+    msg: 'Build:',
+    accepts: [profile1],
+    reasons: new Map([
+      [profile0, [ 'First line (subject) must have a message after the component' ]],
+      [profile2, [
+        "Component invalid, was 'Build:', must be one of these: Build, Legacy",
+        'First line (subject) must have a message after the component'
+      ]],
+      [profile3, [ 'First line (subject) must have a message after the component' ]]
+    ])
+  },
+  {
+    msg: 'Component0:Component1: short message\n\n'
+  },
+  {
+    msg: 'Component: short message\n\n' +
+         '1. List element\n' +
+         '2. List element\n\n' +
+         '* List element\n' +
+         '* List element\n\n' +
+         '- List element\n' +
+         '- List element\n\n' +
+         '+ List element\n' +
+         '+ List element'
+  },
+  {
+    msg: 'Component: message over default of 50 but below limit of 70'
+  },
+  {
+    msg: 'Component: short message\n\n' +
          'Fixes some bug.\n' +
          'Fix some other bug.\n' +
          'And fix these bugs too.\n' +
-         'And fixes other bugs too.\n'
+         'And fixes other bugs too.'
   },
   {
-    msg: 'Component: short message\n' +
-         '\n' +
+    msg: 'Component: short message\n\n' +
          'Resolves some issue.\n' +
          'Resolve some other issue.\n' +
          'And resolve these issues too.\n' +
-         'And resolves some other issues too.\n'
+         'And resolves some other issues too.'
   },
   {
-    msg: 'Component: short message\n' +
-         '\n' +
+    msg: 'Component: short message\n\n' +
          'Closes some issue.\n' +
          'Close some other issue.\n' +
          'And close these issues too.\n' +
          'And closes some other issues too.'
   },
   {
-    msg: 'Component: short message\n' +
-         '\n' +
+    msg: 'Component: short message\n\n' +
          'Fixes #1\n' +
-         'Fixes #123'
+         'Fixes #123',
+    reasons: new Map([
+      [profile3, [
+        'Invalid ticket reference, must be /' + profile3.ticketPattern + '/, was: Fixes #1',
+        'Invalid ticket reference, must be /' + profile3.ticketPattern + '/, was: Fixes #123'
+      ]]
+    ])
   },
   {
-    msg: 'Component: short message\n' +
-         '\n' +
+    msg: 'Component: short message\n\n' +
+         'Fixes #1 Fixes #123',
+    reasons: new Map([
+      [profile3, [
+        'Invalid ticket reference, must be /' + profile3.ticketPattern + '/, was: Fixes #1 Fixes #123'
+      ]]
+    ])
+  },
+  {
+    msg: 'Component: short message\n\n' +
+         'Fixes jquery/jquery#1\n' +
+         'Fixes jquery/jquery#123',
+    reasons: new Map([
+      [profile3, [
+        'Invalid ticket reference, must be /' + profile3.ticketPattern + '/, was: Fixes jquery/jquery#1',
+        'Invalid ticket reference, must be /' + profile3.ticketPattern + '/, was: Fixes jquery/jquery#123'
+      ]]
+    ])
+  },
+  {
+    msg: 'Component: short message\n\n' +
+         'Fixes jquery/jquery#1 Fixes jquery/jquery#123',
+    reasons: new Map([
+      [profile3, [
+        'Invalid ticket reference, must be /' + profile3.ticketPattern + '/, was: Fixes jquery/jquery#1 Fixes jquery/jquery#123'
+      ]]
+    ])
+  },
+  {
+    msg: 'Component: short message\n\n' +
          'Fixes gh-1\n' +
          'Fixes gh-123'
   },
   {
-    msg: 'Component: short message\n' +
-         '\n' +
+    msg: 'Component: short message\n\n' +
+         'Fixes gh-1 Fixes gh-123'
+  },
+  {
+    msg: 'Component: short message\n\n' +
          'Fixes WEB-1\n' +
          'Fixes WEB-123'
   },
   {
-    msg: 'Component: short message\n' +
-         '\n' +
+    msg: 'Component: short message\n\n' +
+         'Fixes WEB-1 Fixes WEB-123'
+  },
+  {
+    msg: 'Component: short message\n\n' +
          'Fixes CRM-1\n' +
          'Fixes CRM-123'
+  },
+  {
+    msg: 'Component: short message\n\n' +
+         'Fixes CRM-1 Fixes CRM-123'
+  },
+  {
+    msg: 'Component: short message\n\n' +
+         'Closes #1\n' +
+         'Closes #123',
+    reasons: new Map([
+      [profile3, [
+        'Invalid ticket reference, must be /' + profile3.ticketPattern + '/, was: Closes #1',
+        'Invalid ticket reference, must be /' + profile3.ticketPattern + '/, was: Closes #123'
+      ]]
+    ])
+  },
+  {
+    msg: 'Component: short message\n\n' +
+         'Closes #1 Closes #123',
+    reasons: new Map([
+      [profile3, [
+        'Invalid ticket reference, must be /' + profile3.ticketPattern + '/, was: Closes #1 Closes #123'
+      ]]
+    ])
+  },
+  {
+    msg: 'Component: short message\n\n' +
+         'Closes jquery/jquery#1\n' +
+         'Closes jquery/jquery#123',
+    reasons: new Map([
+      [profile3, [
+        'Invalid ticket reference, must be /' + profile3.ticketPattern + '/, was: Closes jquery/jquery#1',
+        'Invalid ticket reference, must be /' + profile3.ticketPattern + '/, was: Closes jquery/jquery#123'
+      ]]
+    ])
+  },
+  {
+    msg: 'Component: short message\n\n' +
+         'Closes jquery/jquery#1 Closes jquery/jquery#123',
+    reasons: new Map([
+      [profile3, [
+        'Invalid ticket reference, must be /' + profile3.ticketPattern + '/, was: Closes jquery/jquery#1 Closes jquery/jquery#123'
+      ]]
+    ])
+  },
+  {
+    msg: 'Component: short message\n\n' +
+         'Closes gh-1\n' +
+         'Closes gh-123'
+  },
+  {
+    msg: 'Component: short message\n\n' +
+         'Closes gh-1 Closes gh-123'
+  },
+  {
+    msg: 'Component: short message\n\n' +
+         'Closes WEB-1\n' +
+         'Closes WEB-123'
+  },
+  {
+    msg: 'Component: short message\n\n' +
+         'Closes WEB-1 Closes WEB-123'
+  },
+  {
+    msg: 'Component: short message\n\n' +
+         'Closes CRM-1\n' +
+         'Closes CRM-123'
+  },
+  {
+    msg: 'Component: short message\n\n' +
+         'Closes CRM-1 Closes CRM-123'
+  },
+  {
+    msg: 'Component: short message\n\n' +
+         'Fixes #123\n' +
+         'Fixes #1 Fixes #123\n' +
+         'Fixes gh-123\n' +
+         'Fixes gh-1 Fixes gh-123\n' +
+         'Fixes WEB-123\n' +
+         'Fixes WEB-1 Fixes WEB-123\n' +
+         'Fixes CRM-123\n' +
+         'Fixes CRM-1 Fixes CRM-123\n',
+    rejects: [profile3]
+  },
+  {
+    msg: 'Component: short message\n\n' +
+         'Closes #123\n' +
+         'Closes #1 Closes #123\n' +
+         'Closes gh-123\n' +
+         'Closes gh-1 Closes gh-123\n' +
+         'Closes WEB-123\n' +
+         'Closes WEB-1 Closes WEB-123\n' +
+         'Closes CRM-123\n' +
+         'Closes CRM-1 Closes CRM-123\n',
+    rejects: [profile3]
+  },
+  {
+    msg: 'Component: short message\n\n' +
+         'Closes #123\n' +
+         'Fixes #1 Closes #123\n' +
+         'Fixes gh-123\n' +
+         'Closes gh-1 Fixes gh-123\n' +
+         'Closes WEB-123\n' +
+         'Fixes WEB-1 Closes WEB-123\n' +
+         'Fixes CRM-123\n' +
+         'Closes CRM-1 Fixes CRM-123\n',
+    rejects: [profile3]
+  },
+  {
+    msg: 'Component: short message\n\n' +
+         'Long description\n\n' +
+         'Closes #42\n\n' +
+         'An afterthought is ok',
+    reasons: new Map([
+      [profile3, [ 'Invalid ticket reference, must be /' + profile3.ticketPattern + '/, was: Closes #42' ]]
+    ])
+  },
+  {
+    msg: 'Component: short message\n\n' +
+         'Closes: gh-1',
+    reasons: new Map([
+      [profile0, [ 'Invalid ticket reference, must be /' + profile0.ticketPattern + '/, was: Closes: gh-1' ]],
+      [profile1, [ 'Invalid ticket reference, must be /' + profile1.ticketPattern + '/, was: Closes: gh-1' ]],
+      [profile3, [ 'Invalid ticket reference, must be /' + profile3.ticketPattern + '/, was: Closes: gh-1' ]]
+    ])
+  },
+  {
+    msg: 'Component: short message\n\n' +
+         'Closing #1',
+    reasons: new Map([
+      [profile0, [ 'Invalid ticket reference, must be /' + profile0.ticketPattern + '/, was: Closing #1' ]],
+      [profile1, [ 'Invalid ticket reference, must be /' + profile1.ticketPattern + '/, was: Closing #1' ]],
+      [profile3, [ 'Invalid ticket reference, must be /' + profile3.ticketPattern + '/, was: Closing #1' ]]
+    ])
+  },
+  {
+    msg: 'Component: short message\n\n' +
+         'Fixing gh-1',
+    reasons: new Map([
+      [profile0, [ 'Invalid ticket reference, must be /' + profile0.ticketPattern + '/, was: Fixing gh-1' ]],
+      [profile1, [ 'Invalid ticket reference, must be /' + profile1.ticketPattern + '/, was: Fixing gh-1' ]],
+      [profile3, [ 'Invalid ticket reference, must be /' + profile3.ticketPattern + '/, was: Fixing gh-1' ]]
+    ])
+  },
+  {
+    msg: 'Component: short message\n\n' +
+         'Resolving WEB-1',
+    reasons: new Map([
+      [profile0, [ 'Invalid ticket reference, must be /' + profile0.ticketPattern + '/, was: Resolving WEB-1' ]],
+      [profile1, [ 'Invalid ticket reference, must be /' + profile1.ticketPattern + '/, was: Resolving WEB-1' ]],
+      [profile3, [ 'Invalid ticket reference, must be /' + profile3.ticketPattern + '/, was: Resolving WEB-1' ]]
+    ])
+  },
+  {
+    msg: '0.0.1'
+  },
+  {
+    msg: 'v0.0.1'
+  },
+  {
+    msg: '512.4096.65536'
+  },
+  {
+    msg: 'v512.4096.65536'
   },
   {
     msg: "Merge branch 'one' into two"
   },
   {
-    msg: 'Merge e8d808b into f040453'
+    msg: 'Merge e8d808b into 0f40453'
   },
   {
-    msg: 'fixup! for git to squash',
-    options: testComponent
+    msg: 'fixup!'
   },
   {
-    msg: 'squash! for git to squish',
-    options: testComponent
+    msg: 'fixup! short message'
   },
   {
-    msg: '[fix]: whatever fix',
-    options: testComponent
+    msg: 'squash!'
   },
   {
-    msg: '[Tmp]: do this and that',
-    options: testComponent
+    msg: 'squash! short message'
   },
   {
-    msg: 'fixedToolbar: Prevent resize'
+    msg: '[fix]: short message'
   },
   {
-    msg: 'Docs:Tests: Remove legacy code & add support comments where needed\n' +
-         '\n' +
-         'This commits backports some changes done in the patch to the then-existing\n' +
-         'compat branch that removed support for old browsers and added some support\n' +
-         'comments.\n' +
-         '\n' +
-         'Refs 90d7cc1d8b2ea7ac75f0eacb42439349c9c73278'
+    msg: '[Tmp]: short message'
   },
   {
-    msg: 'Support: improve support properties computation\n' +
-         '\n' +
-         '* Remove div from the memory if it is not needed anymore\n' +
-         '\n' +
-         '* Make `computeStyleTests` method a singleton\n' +
-         '\n' +
-         'Fixes gh-3018 Closes gh-3021'
+    msg: '',
+    reasons: new Map([
+      [profile0, [
+        'First line (subject) must not be empty',
+        'First line (subject) must indicate the component',
+        'First line (subject) must have a message after the component'
+      ]],
+      [profile1, [ 'First line (subject) must not be empty' ]],
+      [profile2, [
+        'First line (subject) must not be empty',
+        'First line (subject) must indicate the component',
+        'First line (subject) must have a message after the component'
+      ]],
+      [profile3, [
+        'First line (subject) must not be empty',
+        'First line (subject) must indicate the component',
+        'First line (subject) must have a message after the component'
+      ]]
+    ])
   },
   {
-    msg: 'Tests: add additional test for jQuery.isPlainObject\n' +
-         '\n' +
-         'Ref 00575d4d8c7421c5119f181009374ff2e7736127\n' +
-         'Also see discussion in\n' +
-         'https://github.com/jquery/jquery/pull/2970#discussion_r54970557'
-  },
-  {
-    msg: 'Revert "Offset: account for scroll when calculating position"\n' +
-         '\n' +
-         'This reverts commit 2d715940b9b6fdeed005cd006c8bf63951cf7fb2.\n' +
-         'This commit provoked new issues: gh-2836, gh-2828.\n' +
-         'At the meeting, we decided to revert offending commit\n' +
-         '(in all three branches - 2.2-stable, 1.12-stable and master)\n' +
-         'and tackle this issue in 3.x.\n' +
-         '\n' +
-         'Fixes gh-2828'
-  },
-  {
-    msg: 'Revert "Attributes: Remove undocumented .toggleClass( boolean ) signature"\n' +
-         '\n' +
-         'This reverts commit 53f798cf4d783bb813b4d1ba97411bc752b275f3.\n' +
-         '\n' +
-         '- Turns out this is documented, even if not fully. Need to deprecate before removal.',
-    options: {
-      limits: {
-        subject: 90,
-        other: 90
+    msg: 'Component: short message\n\n' +
+         '# Please enter the commit message . Lines starting\n' +
+         "# with '#' will be ignored, an empty message aborts the commit.\n" +
+         '# On branch commitplease-rocks\n' +
+         '# Changes to be committed:\n' +
+         '#	modified:   test.js\n' +
+         '# ------------------------ >8 ------------------------\n' +
+         '# Do not touch the line above.\n' +
+         '# Everything below will be removed.\n' +
+         'diff --git a/test.js b/test.js\n' +
+         'index c689515..706b86f 100644\n' +
+         '--- a/test.js\n' +
+         '+++ b/test.js\n' +
+         '@@ -1,14 +1,10 @@\n' +
+         "var validate = require('./lib/validate')\n" +
+         "var sanitize = require('./lib/sanitize')\n"
+  }
+]
+
+// reserve for Angular
+var profiles1 = []
+var messages1 = []
+
+var groups = new Map([
+  [profiles0, messages0],
+  [profiles1, messages1]
+])
+
+exports.tests = function (test) {
+  for (var group of groups) {
+    testGroup(test, group)
+  }
+
+  test.done()
+}
+
+function testGroup (test, group) {
+  var [profiles, messages] = [group[0], group[1]]
+
+  for (var profile of profiles) {
+    for (var message of messages) {
+      var excludes = message.excludes
+      if (excludes && excludes.indexOf(profile) !== -1) {
+        continue
+      }
+
+      var msg = message.msg
+
+      var accepts = message.accepts
+      if (accepts && accepts.indexOf(profile) !== -1) {
+        var result = validate(sanitize(msg), profile)
+        test.deepEqual(result, [], '\n' + msg)
+
+        continue
+      }
+
+      var rejects = message.rejects
+      if (rejects && rejects.indexOf(profile) !== -1) {
+        var result = validate(sanitize(msg), profile)
+        test.notDeepEqual(result, [], '\n' + msg)
+
+        continue
+      }
+
+      var reasons = message.reasons
+      if (reasons && reasons.get(profile)) {
+        var reason = reasons.get(profile)
+
+        var result = validate(sanitize(msg), profile)
+        test.deepEqual(result, reason, '\n' + msg)
+
+        continue
+      }
+
+      // assume default: profile must pass the test
+      var result = validate(sanitize(msg), profile)
+      test.deepEqual(result, [], '\n' + msg)
+    }
+  }
+
+  for (var message of messages) {
+    var msg = message.msg
+
+    var accepts = message.accepts
+    if (accepts) {
+      for (var profile of accepts) {
+        if (profiles.indexOf(profile) === -1) {
+          var result = validate(sanitize(msg), profile)
+          test.deepEqual(result, [], '\n' + msg)
+        }
       }
     }
-  },
-  {
-    msg: 'Event: Separate trigger/simulate into its own module\n' +
-         '\n' +
-         'Fixes gh-1864\n' +
-         'Closes gh-2692\n' +
-         '\n' +
-         'This also pulls the focusin/out special event into its own module, since that\n' +
-         'depends on simulate(). NB: The ajax module triggers events pretty heavily.'
-  }
-]
 
-var ticketPattern = new RegExp(validate.defaults.ticketPattern)
-
-var invalid = [
-  {
-    msg: '',
-    expected: [ 'First line (subject) must not be empty' ],
-    options: {
-      component: false
+    var rejects = message.rejects
+    if (rejects) {
+      for (var profile of rejects) {
+        if (profiles.indexOf(profile) === -1) {
+          var result = validate(sanitize(msg), profile)
+          test.notDeepEqual(result, [], '\n' + msg)
+        }
+      }
     }
-  },
-  {
-    msg: 'Test: Message',
-    expected: [ "Component invalid, was 'Test', must be one of these: Build, Legacy" ],
-    options: {
-      components: [ 'Build', 'Legacy' ]
+
+    var reasons = message.reasons
+    if (reasons) {
+      for (var key2val of reasons) {
+        var [profile, reason] = [key2val[0], key2val[1]]
+        if (profiles.indexOf(profile) === -1) {
+          var result = validate(sanitize(msg), profile)
+          test.deepEqual(result, reason, '\n' + msg)
+        }
+      }
     }
-  },
-  {
-    msg: '',
-    expected: [
-      'First line (subject) must not be empty',
-      'First line (subject) must indicate the component',
-      'First line (subject) must have a message after the component'
-    ]
-  },
-  {
-    msg: 'Component: short message but actually a little bit over default character limit',
-    expected: [ 'First line (subject) must be no longer than 72 characters' ]
-  },
-  {
-    msg: 'foo:',
-    expected: [ 'First line (subject) must have a message after the component' ]
-  },
-  {
-    msg: 'no component here',
-    expected: [ 'First line (subject) must indicate the component' ]
-  },
-  {
-    msg: 'component: bla\ntext on next line',
-    expected: [ 'Second line must always be empty' ]
-  },
-  {
-    msg: 'component: bla\n\nline too long beyond 80 chars line too long beyond' +
-      'line too long line too long line too long',
-    expected: [ 'Commit message line 3 too long: 91 characters, only 80 allowed. Was: line too long beyond[...]' ]
-  },
-  {
-    msg: 'Docs: Fix a typo\n\nCloses: gh-155',
-    expected: [ 'Invalid ticket reference, must be ' + ticketPattern + ', was: Closes: gh-155' ]
-  },
-  {
-    msg: 'Bla: blub\n\nClosing #1',
-    expected: [ 'Invalid ticket reference, must be ' + ticketPattern + ', was: Closing #1' ]
-  },
-  {
-    msg: 'Bla: blub\n\nFixing gh-1',
-    expected: [ 'Invalid ticket reference, must be ' + ticketPattern + ', was: Fixing gh-1' ]
-  },
-  {
-    msg: 'Bla: blub\n\nResolving xy-9991',
-    expected: [ 'Invalid ticket reference, must be ' + ticketPattern + ', was: Resolving xy-9991' ]
-  },
-  {
-    msg: 'bla: blu\n\n# comment\nResolving xy12312312312',
-    expected: [ 'Invalid ticket reference, must be ' + ticketPattern + ', was: Resolving xy12312312312' ]
-  },
-  {
-    msg: 'Component: short message\n\nFixes #123',
-    options: {
-      ticketPattern: /^(Closes|Fixes) ([A-Z]{2,}-)[0-9]+/
-    },
-    expected: [ 'Invalid ticket reference, must be ' + '/^(Closes|Fixes) ([A-Z]{2,}-)[0-9]+/' + ', was: Fixes #123' ]
   }
-]
-
-exports.valid = function (test) {
-  valid.forEach(function (check, index) {
-    test.deepEqual(validate(sanitize(check.msg), check.options), [], 'valid ' + index +
-      ' ' + check.msg)
-  })
-  test.done()
-}
-
-exports.invalid = function (test) {
-  invalid.forEach(function (check, index) {
-    test.deepEqual(validate(sanitize(check.msg), check.options), check.expected,
-      'invalid ' + index + ' ' + check.msg)
-  })
-  test.done()
-}
-
-exports.sanitze = function (test) {
-  test.strictEqual(sanitize(messageWithMultipleLines), messageWithMultipleLines)
-  test.strictEqual(sanitize(messageWithDiff), 'Component: short message\n\nsome text\nmore text')
-  test.done()
 }


### PR DESCRIPTION
Curently, I am working on the change that is supposed to solve #33. This PR demonstrates that it is possible by simply changing the `ticketPattern` a bit. However, this PR massively changes `test.js`. Here is the reason for it:

Previously, whenever `test.js` tested commitplease against a commit message that required a change in the default settings, that change would be tested against that one message. The `test.js` proposed here allows to first create a number of commitplease configurations and then test them against all (or some subset) of messages (without copy-pasting the messages themselves). The commit message explains the implementation details a bit more.

I am sure there are many things that can be done better, please take a look. As for prohibiting `#nnnn`-style references, `options3` in `test.js` does that and still works fine on all of the messages.

Update: I see that Node 0.12 and Node 4 failed in CI (Node-stable works though). Sorry, I was coding with Node 6 in mind, will fix that.