### PR TITLE
Sanitize: support custom core.commentchar that can be set by git

### DIFF
--- a/lib/sanitize.js
+++ b/lib/sanitize.js
@@ -1,6 +1,23 @@
+var process = require('child_process')
+var command = 'git config --get core.commentchar'
+var comment = '#'
+
+try {
+  comment = process.execSync(command).toString().trim()
+} catch (error) {
+  // errors.status === 1 if the following:
+  // a) 'core.commentchar' has not been set (git defaults it to #)
+  // b) this is not a git repository
+  // c) maybe something else?
+  if (error.status !== 1) {
+    throw error
+  }
+}
+
 var scissor = /# ------------------------ >8 ------------------------[\s\S]+/
 module.exports = function (value) {
+  var isComment = new RegExp('^' + comment)
   return value.replace(scissor, '').split(/\n/).filter(function (line) {
-    return !/^#/.test(line)
+    return !isComment.test(line)
   }).join('\n').trim()
 }


### PR DESCRIPTION
My problem ended up being twofold:

`git` returns various non-zeroes when there is something wrong with the setting, see [Description -> This command will fail ...][1]. So, `execSync` was throwing that non-zero as an error while I was thinking I must have done something wrong and caused the error. And when I was trying simpler scripts, I was still actually running the original script and getting the same error. Yay.

Closes #27 

[1]: https://git-scm.com/docs/git-config 

