### PR TITLE
Uninstall: fix automatic commit-msg removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,26 @@ if (errors.length) {
 }
 ```
 
+## Uninstall
+
+Remove your configurations of commitplease from your package.json, if any.
+
+If you are running `npm 2.x`, then:
+
+```
+npm uninstall commitplease --save-dev
+```
+
+If you are running `npm 3.x`, you will have to remove the hook manually:
+
+```
+rm .git/hooks/commit-msg
+npm uninstall commitplease --save-dev
+```
+
+There is [an open issue](https://github.com/npm/npm/issues/13381) to npm about this.
+
+
 ## License
 Copyright Jörn Zaefferer  
 Released under the terms of the MIT license.

--- a/commit-msg-hook.js
+++ b/commit-msg-hook.js
@@ -1,4 +1,4 @@
 #!/usr/bin/env node
 
-// `commitplease-original`
+// commitplease-original
 require('commitplease')

--- a/setup.js
+++ b/setup.js
@@ -54,7 +54,7 @@ var context = {
 if (fs.existsSync(hook)) {
   context.hookExists = true
   var content = fs.readFileSync(hook, 'utf-8')
-  if (content && content.split('\n')[ 1 ] === '// commitplease-original') {
+  if (content && content.split('\n')[ 2 ] === '// commitplease-original') {
     context.selfmadeHook = true
   }
 }


### PR DESCRIPTION
My `nvm --version` is `0.31.0`

With the following node/npm combinations

 1. `node --version` at `v0.12.15` and `npm --version` at `2.15.1`
 1. `node --version` at `4.4.7` and `npm --version` at `2.15.8`

this sequence of commands

```
mkdir project && cd project && git init >/dev/null
npm init --yes >/dev/null
npm install ../commitplease
npm uninstall ../commitplease
```
calls `install.js` and `uninstall.js` properly. It does not remove the hook though.

With `node --version` at `6.3.0` and `npm --version` at `3.10.3` the same sequence of commands does not trigger uninstall.js at all.

With `node --version` at `6.1.0` and `npm --version` at `3.8.6` the same sequence of commands triggers install.js during `npm uninstall ../commitplease`, i.e. triggers the wrong script.