### PR TITLE
Avoid race condition in install.js when creating .git/hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ npm install -g commitplease
 
 A git version of 1.8.5 or newer is recommended. If you use `git commit --verbose`, it is required.
 
+You could also install a global commitplease executable and put it into a `package.json` script or as a git hook of your choice. Here is an example with a `pre-push` hook:
+
+```
+#!/bin/sh
+
+npm run commitplease --silent
+```
+
+And `chmod +x .git/hooks/pre-push`. Now each time you do a `git push`, the hook will be checking **all** commits on current branch.
+
 ## Usage
 
 The following ways to begin a commit message are special and always valid:

--- a/install.js
+++ b/install.js
@@ -9,13 +9,28 @@ if (options && options.nohook) {
   process.exit(0)
 }
 
+function xmkdirSync (path, mode) {
+  try {
+    fs.mkdirSync(path, mode)
+  } catch (err) {
+    if (/EPERM/.test(err.message)) {
+      console.error('Failed to create: ' + path)
+      console.error('Make sure you have the necessary permissions')
+      process.exit(1)
+    } else if (/EEXIST/.test(err.message)) {
+      // do nothing
+    } else {
+      console.error(err)
+      process.exit(1)
+    }
+  }
+}
+
 var git = path.resolve(process.cwd(), '..', '..', '.git')
 var hooks = path.join(git, 'hooks')
 
-if (!fs.existsSync(git) || !fs.existsSync(hooks)) {
-  fs.mkdirSync(git)
-  fs.mkdirSync(hooks)
-}
+xmkdirSync(git, parseInt('755', 8))
+xmkdirSync(hooks, parseInt('755', 8))
 
 var dstHook = path.join(hooks, 'commit-msg')
 var srcHook = path.relative(hooks, 'commit-msg-hook.js')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commitplease",
-  "version": "2.7.0",
+  "version": "2.7.1-0",
   "description": "Validates strings as commit messages",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Closes #76 

I am not sure how to properly exit from a `catch` block: with `process.exit(1)` or rethrowing the error.