### PR TITLE
Hook compat with Linux-like environment for windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ module.exports = function () {
   var options = getOptions()
   var message = path.join('.git', 'COMMIT_EDITMSG')
 
-  if (argv[0] === message) {
+  if (path.normalize(argv[0]) === message) {
     runValidate(fs.readFileSync(message, 'utf8').toString(), options)
 
     process.exit(0)


### PR DESCRIPTION
This fix an issue of comparing paths when working in a windows environment and using a Linux-like environment (such as Cygwin, MSys2 MinGW, ...)

I think that could be good to compare the result of `path.join('.git', 'COMMIT_EDITMSG')`, which uses `path.normalize()` in the hood (according to the [docs](https://nodejs.org/api/path.html#path_path_join_paths)), with something that also result from a `path.normalize()`

fixes #89 