### PR TITLE
Reuse commit messages that failed previous style check

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,27 @@ function getOptions () {
   pkg = pkg.commitplease || {}
   npm = npm.commitplease || {}
 
-  return objectAssign(pkg, npm)
+  var options = objectAssign(pkg, npm)
+
+  var base = {
+    'oldMessagePath': defaults.oldMessagePath,
+    'oldMessageSeconds': defaults.oldMessageSeconds
+  }
+
+  if (options === undefined ||
+      options.style === undefined ||
+      options.style === 'jquery') {
+    return objectAssign(base, defaults.jquery, options)
+  } else if (options.style === 'angular') {
+    return objectAssign(base, defaults.angular, options)
+  }
+
+  console.error(chalk.red(
+    'Style ' + options.style + ' is not recognised\n' +
+    'Did you mistype it in package.json?'
+  ))
+
+  process.exit(1)
 }
 
 function runValidate (message, options) {

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ var objectAssign = require('object-assign')
 
 var validate = require('./lib/validate')
 var sanitize = require('./lib/sanitize')
+var defaults = require('./lib/defaults')
 
 function getOptions () {
   var pkg = path.join(process.cwd(), 'package.json')
@@ -38,6 +39,9 @@ function runValidate (message, options) {
     } else if (options.style === 'angular') {
       console.error('\nSee https://bit.ly/angular-guidelines')
     }
+
+    // save a poorly formatted message and reuse it at a later commit
+    fs.writeFileSync(defaults.oldMessagePath, message)
 
     process.exit(1)
   }
@@ -106,4 +110,5 @@ module.exports = function () {
   })
 }
 
+module.exports.defaults = defaults
 module.exports.getOptions = getOptions

--- a/install.js
+++ b/install.js
@@ -46,22 +46,17 @@ var srcHooks = [srcCommitHook, srcPrepareHook]
 
 // loop twice, try to avoid getting partially installed
 
-var i, dstHook, srcHook
-
-for (i = 0; i < dstHooks.length; ++i) {
-  dstHook = dstHooks[i]
-
+dstHooks.forEach(function (dstHook) {
   if (fs.existsSync(dstHook)) {
     console.log(chalk.red('The following hook already exists:\n' + dstHook))
     console.log(chalk.red('Remove it and install this package again to install commitplease properly'))
 
     process.exit(0)
   }
-}
+})
 
-for (i = 0; i < dstHooks.length; ++i) {
-  dstHook = dstHooks[i]
-  srcHook = srcHooks[i]
+dstHooks.forEach(function (dstHook, i) {
+  var srcHook = srcHooks[i]
 
   try {
     fs.writeFileSync(dstHook, fs.readFileSync(srcHook))
@@ -78,4 +73,4 @@ for (i = 0; i < dstHooks.length; ++i) {
 
     throw e
   }
-}
+})

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -45,7 +45,8 @@ var defaults = {
     ],
     scope: '\\S+.*'
   },
-  oldMessagePath: path.join('.git', 'COMMIT_EDITMSG_OLD')
+  oldMessagePath: path.join('.git', 'COMMIT_EDITMSG_OLD'),
+  oldMessageSeconds: 300
 }
 
 module.exports = defaults

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -1,3 +1,5 @@
+var path = require('path')
+
 var defaults = {
   jquery: {
     style: 'jquery',
@@ -42,7 +44,8 @@ var defaults = {
       'feat', 'fix', 'docs', 'style', 'refactor', 'perf', 'test', 'chore'
     ],
     scope: '\\S+.*'
-  }
+  },
+  oldMessagePath: path.join('.git', 'COMMIT_EDITMSG_OLD')
 }
 
 module.exports = defaults

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -1,5 +1,3 @@
-var defaults = require('./defaults.js')
-
 var styles = {
   'jquery': require('./styles/jquery.js'),
   'angular': require('./styles/angular.js')
@@ -10,8 +8,6 @@ var tickets = require('./utils/tickets')
 
 var semver = require('semver')
 
-var objectAssign = require('object-assign')
-
 module.exports = function (message, options) {
   if (message === undefined) {
     return ['Commit message is undefined, abort with error']
@@ -21,19 +17,6 @@ module.exports = function (message, options) {
     return ['Commit message is not a string, abort with error']
   } else if (message.length === 0) {
     return ['Commit message is empty, abort with error']
-  }
-
-  if (options === undefined ||
-      options.style === undefined ||
-      options.style === 'jquery') {
-    options = objectAssign({}, defaults.jquery, options)
-  } else if (options.style === 'angular') {
-    options = objectAssign({}, defaults.angular, options)
-  } else {
-    return [
-      'Style ' + options.style + ' is not recognised\n' +
-      'Did you mistype it in package.json?'
-    ]
   }
 
   var lines = message.split('\n')

--- a/prepare-commit-msg-hook.js
+++ b/prepare-commit-msg-hook.js
@@ -2,14 +2,25 @@
 
 var fs = require('fs')
 
-var commitplease = require('commitplease')
+var getOptions = require('commitplease').getOptions
 
-var oldMessagePath = commitplease.defaults.oldMessagePath
+var options = getOptions()
+
+var oldMessagePath = options.oldMessagePath
+var oldMessageSeconds = options.oldMessageSeconds
 
 if (fs.existsSync(oldMessagePath)) {
   // There is an old message that was previously rejected by us
   // Suggest it to the user so they do not have to start from scratch
-  fs.writeFileSync(process.argv[2], fs.readFileSync(oldMessagePath).toString())
+
+  var mtime = new Date(fs.statSync(oldMessagePath).mtime)
+
+  // Date.now() - mtime.getTime() is milliseconds, convert to minutes
+  if ((Date.now() - mtime.getTime()) / 1000 < oldMessageSeconds) {
+    fs.writeFileSync(
+      process.argv[2], fs.readFileSync(oldMessagePath).toString()
+    )
+  }
 
   fs.unlinkSync(oldMessagePath)
 }

--- a/prepare-commit-msg-hook.js
+++ b/prepare-commit-msg-hook.js
@@ -2,17 +2,16 @@
 
 var fs = require('fs')
 
-var getOptions = require('commitplease').getOptions
-
-var options = getOptions()
+var options = require('commitplease').getOptions()
 
 var oldMessagePath = options.oldMessagePath
 var oldMessageSeconds = options.oldMessageSeconds
 
-if (fs.existsSync(oldMessagePath)) {
-  // There is an old message that was previously rejected by us
+try {
+  // There may be an old message that was previously rejected by us
   // Suggest it to the user so they do not have to start from scratch
 
+  // Will throw ENOENT if no such file, ask forgiveness not permission
   var mtime = new Date(fs.statSync(oldMessagePath).mtime)
 
   // Date.now() - mtime.getTime() is milliseconds, convert to seconds
@@ -21,4 +20,10 @@ if (fs.existsSync(oldMessagePath)) {
   }
 
   fs.unlinkSync(oldMessagePath)
+} catch (err) {
+  if (!/ENOENT/.test(err.message)) {
+    throw err
+  }
+
+  // there is no old message to reuse, swallow the exception
 }

--- a/prepare-commit-msg-hook.js
+++ b/prepare-commit-msg-hook.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+
+var fs = require('fs')
+
+var commitplease = require('commitplease')
+
+var oldMessagePath = commitplease.defaults.oldMessagePath
+
+if (fs.existsSync(oldMessagePath)) {
+  // There is an old message that was previously rejected by us
+  // Suggest it to the user so they do not have to start from scratch
+  fs.writeFileSync(process.argv[2], fs.readFileSync(oldMessagePath).toString())
+
+  fs.unlinkSync(oldMessagePath)
+}

--- a/prepare-commit-msg-hook.js
+++ b/prepare-commit-msg-hook.js
@@ -15,11 +15,9 @@ if (fs.existsSync(oldMessagePath)) {
 
   var mtime = new Date(fs.statSync(oldMessagePath).mtime)
 
-  // Date.now() - mtime.getTime() is milliseconds, convert to minutes
+  // Date.now() - mtime.getTime() is milliseconds, convert to seconds
   if ((Date.now() - mtime.getTime()) / 1000 < oldMessageSeconds) {
-    fs.writeFileSync(
-      process.argv[2], fs.readFileSync(oldMessagePath).toString()
-    )
+    fs.writeFileSync(process.argv[2], fs.readFileSync(oldMessagePath))
   }
 
   fs.unlinkSync(oldMessagePath)

--- a/uninstall.js
+++ b/uninstall.js
@@ -3,14 +3,28 @@ var path = require('path')
 
 var hooks = path.join(process.cwd(), '..', '..', '.git', 'hooks')
 
-var dstHook = path.join(hooks, 'commit-msg')
-var srcHook = path.relative(hooks, 'commit-msg-hook.js')
+var dstCommitHook = path.join(hooks, 'commit-msg')
+var srcCommitHook = path.relative(hooks, 'commit-msg-hook.js')
 
-if (fs.existsSync(dstHook) && fs.existsSync(srcHook)) {
-  var githook = fs.readFileSync(dstHook, 'utf-8')
-  var comhook = fs.readFileSync(srcHook, 'utf-8')
-  if (githook.toString() === comhook.toString()) {
-    console.log('Removing the hook installed by commitplease')
-    fs.unlinkSync(dstHook)
+var dstPrepareHook = path.join(hooks, 'prepare-commit-msg')
+var srcPrepareHook = path.relative(hooks, 'prepare-commit-msg-hook.js')
+
+var dstHooks = [dstCommitHook, dstPrepareHook]
+var srcHooks = [srcCommitHook, srcPrepareHook]
+
+for (var i = 0; i < dstHooks.length; ++i) {
+  var dstHook = dstHooks[i]
+  var srcHook = srcHooks[i]
+
+  if (fs.existsSync(dstHook) && fs.existsSync(srcHook)) {
+    var githook = fs.readFileSync(dstHook)
+    var comhook = fs.readFileSync(srcHook)
+
+    if (githook.toString() === comhook.toString()) {
+      console.log('Removing the following hook:')
+      console.log(dstHook)
+
+      fs.unlinkSync(dstHook)
+    }
   }
 }

--- a/uninstall.js
+++ b/uninstall.js
@@ -28,3 +28,17 @@ for (var i = 0; i < dstHooks.length; ++i) {
     }
   }
 }
+
+try {
+  var options = require('commitplease').getOptions()
+
+  var oldMessagePath = path.join(
+    process.cwd(), '..', '..', options.oldMessagePath
+  )
+
+  fs.unlinkSync(oldMessagePath)
+} catch (err) {
+  if (!/ENOENT/.test(err.message)) {
+    throw err
+  }
+}


### PR DESCRIPTION
This PR is a work-in-progress about improving feedback flow as discussed in #85 

Currently, the base case works: if style check fails, the message is saved in `COMMIT_EDITMSG_OLD` and suggested to the user during the next commit attempt.

However, this needs some thought/testing before merging. Here is an example scenario that causes problems now:

1. The user does a `git commit --amend`
2. The message they enter fails validation, the commit does not happen.
3. The user decides they do not want an amend after all, they revert all the work and forget about it.
4. After a while, the user makes a completely different contribution.
5. When they do a `git commit`, they get an old commit message that failed long ago
6. Confusion?

Or maybe I am just overthinking it, let me know.