### PR TITLE
Add getProjectPath() to compute path to parent project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - '0.12' # Legacy
-  - '4' # LTS
+  - '4' # LTS Argon
+  - '6' # LTS Boron
   - 'stable'

--- a/index.js
+++ b/index.js
@@ -4,16 +4,13 @@ var path = require('path')
 var chalk = require('chalk')
 var Git = require('git-tools')
 
-var endsWith = require('ends-with')
-var objectAssign = require('object-assign')
-
 var validate = require('./lib/validate')
 var sanitize = require('./lib/sanitize')
 var defaults = require('./lib/defaults')
 
 function sliceEnvPath (suffix) {
   var p = process.env.PATH.split(':').filter(
-    function (p) {return endsWith(p, suffix)}
+    function (p) {return p.endsWith(suffix)}
   )
 
   if (p.length === 1) {
@@ -63,7 +60,7 @@ function getOptions () {
   pkg = pkg.commitplease || {}
   npm = npm.commitplease || {}
 
-  var options = objectAssign(pkg, npm)
+  var options = Object.assign(pkg, npm)
 
   var base = {
     'oldMessagePath': defaults.oldMessagePath,
@@ -73,9 +70,9 @@ function getOptions () {
   if (options === undefined ||
       options.style === undefined ||
       options.style === 'jquery') {
-    return objectAssign(base, defaults.jquery, options)
+    return Object.assign(base, defaults.jquery, options)
   } else if (options.style === 'angular') {
-    return objectAssign(base, defaults.angular, options)
+    return Object.assign(base, defaults.angular, options)
   }
 
   console.error(chalk.red(

--- a/index.js
+++ b/index.js
@@ -8,6 +8,9 @@ var validate = require('./lib/validate')
 var sanitize = require('./lib/sanitize')
 var defaults = require('./lib/defaults')
 
+// If there is a path in process.env.PATH that looks like this:
+// path = prefix + suffix (where suffix is the function argument)
+// then slice off the suffix and return the prefix, otherwise undefiend
 function sliceEnvPath (suffix) {
   var p = process.env.PATH.split(':').filter(
     function (p) {return p.endsWith(suffix)}

--- a/index.js
+++ b/index.js
@@ -10,9 +10,37 @@ var validate = require('./lib/validate')
 var sanitize = require('./lib/sanitize')
 var defaults = require('./lib/defaults')
 
+// Need to find the path to the project that is installing
+// commitplease. Previously, process.cwd() made the job easy but its
+// output changed with node v8.1.2
+function getProjectPath () {
+  // Use the fact that npm will inject a path that ends with
+  // commitplease/node_modules/.bin into PATH
+  var p = process.env.PATH.split(':').filter(
+    function (p) {
+      return p.endsWith(path.join('commitplease', 'node_modules', '.bin'))
+    }
+  )
+
+  if (p.length !== 1) {
+    console.error(chalk.red('Failed to find project path\n'))
+  }
+
+  // Removing suffix node_modules/commitplease/node_modules/.bin will
+  // give the absolute path to the project root
+  p = p[0].split(path.sep)
+  p = p.slice(0, p.length - 4)
+
+  return path.sep + p.join(path.sep)
+}
+
 function getOptions () {
-  var pkg = path.join(process.cwd(), 'package.json')
-  var npm = path.join(process.cwd(), '.npmrc')
+  var projectPath = getProjectPath()
+
+  console.log(projectPath)
+
+  var pkg = path.join(projectPath, 'package.json')
+  var npm = path.join(projectPath, '.npmrc')
 
   pkg = fs.existsSync(pkg) && require(pkg) || {}
   npm = fs.existsSync(npm) && ini.parse(fs.readFileSync(npm, 'utf8')) || {}

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var path = require('path')
 var chalk = require('chalk')
 var Git = require('git-tools')
 
+var endsWith = require('ends-with')
 var objectAssign = require('object-assign')
 
 var validate = require('./lib/validate')
@@ -12,18 +13,21 @@ var defaults = require('./lib/defaults')
 
 // Need to find the path to the project that is installing
 // commitplease. Previously, process.cwd() made the job easy but its
-// output changed with node v8.1.2
+// output changed with node v8.1.2 (at least compared to 7.10.0)
 function getProjectPath () {
   // Use the fact that npm will inject a path that ends with
-  // commitplease/node_modules/.bin into PATH
+  // commitplease/node_modules/.bin into process.env.PATH
   var p = process.env.PATH.split(':').filter(
     function (p) {
-      return p.endsWith(path.join('commitplease', 'node_modules', '.bin'))
+      return endsWith(p, path.join('commitplease', 'node_modules', '.bin'))
     }
   )
 
   if (p.length !== 1) {
     console.error(chalk.red('Failed to find project path\n'))
+
+    // Just leave with zero so as not to interrupt install
+    process.exit(0)
   }
 
   // Removing suffix node_modules/commitplease/node_modules/.bin will
@@ -36,8 +40,6 @@ function getProjectPath () {
 
 function getOptions () {
   var projectPath = getProjectPath()
-
-  console.log(projectPath)
 
   var pkg = path.join(projectPath, 'package.json')
   var npm = path.join(projectPath, '.npmrc')

--- a/install.js
+++ b/install.js
@@ -4,8 +4,17 @@ var chalk = require('chalk')
 
 var options = require('./index.js').getOptions()
 
-if (options && options.nohook) {
-  console.log('commitplease: package.json or .npmrc set to skip hook')
+// Is this a self-install? If so, do not copy hooks and quit early
+var pkgPath = path.join(options.projectPath, 'package.json')
+var pkg = fs.existsSync(pkgPath) && require(pkgPath)
+
+if (pkg && pkg.name && pkg.name === 'commitplease') {
+  console.log('commitplease: self-install detected, skipping hooks')
+  process.exit(0)
+}
+
+if (options.nohook) {
+  console.log('commitplease: package.json or .npmrc set to skip hooks')
   process.exit(0)
 }
 

--- a/install.js
+++ b/install.js
@@ -29,17 +29,19 @@ function xmkdirSync (path, mode) {
   }
 }
 
-var git = path.resolve(process.cwd(), '..', '..', '.git')
-var hooks = path.join(git, 'hooks')
+var git = path.join(options.projectPath, '.git')
+
+var dstHooksPath = path.join(options.projectPath, '.git', 'hooks')
+var srcHooksPath = path.join(options.projectPath, 'node_modules', 'commitplease')
 
 xmkdirSync(git, parseInt('755', 8))
-xmkdirSync(hooks, parseInt('755', 8))
+xmkdirSync(dstHooksPath, parseInt('755', 8))
 
-var dstCommitHook = path.join(hooks, 'commit-msg')
-var srcCommitHook = path.relative(hooks, 'commit-msg-hook.js')
+var dstCommitHook = path.join(dstHooksPath, 'commit-msg')
+var srcCommitHook = path.join(srcHooksPath, 'commit-msg-hook.js')
 
-var dstPrepareHook = path.join(hooks, 'prepare-commit-msg')
-var srcPrepareHook = path.relative(hooks, 'prepare-commit-msg-hook.js')
+var dstPrepareHook = path.join(dstHooksPath, 'prepare-commit-msg')
+var srcPrepareHook = path.join(srcHooksPath, 'prepare-commit-msg-hook.js')
 
 var dstHooks = [dstCommitHook, dstPrepareHook]
 var srcHooks = [srcCommitHook, srcPrepareHook]

--- a/package.json
+++ b/package.json
@@ -36,10 +36,8 @@
   },
   "dependencies": {
     "chalk": "^1.1.1",
-    "ends-with": "^1.0.1",
     "git-tools": "^0.2.1",
     "ini": "^1.3.4",
-    "object-assign": "^4.1.0",
     "semver": "^5.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commitplease",
-  "version": "2.7.10",
+  "version": "3.0.0",
   "description": "Validates strings as commit messages",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "chalk": "^1.1.1",
+    "ends-with": "^1.0.1",
     "git-tools": "^0.2.1",
     "ini": "^1.3.4",
     "object-assign": "^4.1.0",

--- a/test.js
+++ b/test.js
@@ -2,8 +2,6 @@ var validate = require('./lib/validate')
 var sanitize = require('./lib/sanitize')
 var defaults = require('./lib/defaults')
 
-var objectAssign = require('object-assign')
-
 var jqueryColon =
     'First line must be <Component>: <subject>\n' +
     'Missing colon :'
@@ -32,22 +30,22 @@ var jqueryFirstLine72 =
 
 var jquery0 = defaults.jquery
 
-var jquery1 = objectAssign(
+var jquery1 = Object.assign(
   {}, defaults.jquery, {component: false}
 )
 
-var jquery2 = objectAssign(
+var jquery2 = Object.assign(
   {}, defaults.jquery, {components: ['Build', 'Legacy']}
 )
 
-var jquery3 = objectAssign(
+var jquery3 = Object.assign(
   {}, defaults.jquery, {
     markerPattern: '^((clos|fix|resolv)(e[sd]|ing))|^(refs?)',
     ticketPattern: '^((Closes|Fixes) ([a-zA-Z]{2,}-)[0-9]+)|^(Refs? [^#])'
   }
 )
 
-var jquery4 = objectAssign(
+var jquery4 = Object.assign(
   {}, defaults.jquery, {components: ['^\\[\\w+-\\d+\\]']}
 )
 


### PR DESCRIPTION
Previously, process.cwd() did the job just fine but with node v8.1.2
(compared to 7.10.0 at least) the output has changed. So, use the
following hack: when installing a node package, npm adds it to PATH.
Since we know:
a) the suffix of that path entry (commitplease/node_modules/.bin)
b) the fact that the other project is installing commitplease

then find that entry and use its prefix as parent project path

Refs: https://github.com/jquery/jquery/issues/3708