### PR TITLE
Index: Support custom options via environment variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,6 +58,24 @@ function getProjectPath () {
   return path.resolve(process.cwd())
 }
 
+function getOverrides (env) {
+  var options = {}
+  var prefix = 'npm_config_commitplease_'
+  for (var key in env) {
+
+    // For explicit environment variable overrides.
+    // npm also sets these implicitly for CLI arguments (--commitplease-*),
+    // and for commitplease_* prefixed entries in an .npmrc file.
+    // Note that getOptions() has its own handling for npmrc files, because
+    // we prefer entries to be in their own [commitplease] section,
+    // which npm does not add individually into process.env.
+    if (key.indexOf(prefix) !== -1) {
+      options[key.replace(prefix, '')] = env[key]
+    }
+  }
+  return options
+}
+
 function getOptions () {
   var projectPath = getProjectPath()
 
@@ -70,7 +88,9 @@ function getOptions () {
   pkg = pkg.commitplease || {}
   npm = npm.commitplease || {}
 
-  var options = Object.assign(pkg, npm)
+  var overrides = getOverrides(process.env)
+
+  var options = Object.assign(pkg, npm, overrides)
 
   var base = {
     'projectPath': projectPath,


### PR DESCRIPTION
When working with a Node-based project in a secure isolated environment, it is imho best practice to only expose the working directory of that one project, and to disallow write access to `.git` as this would allow remote shell execution outside the environment when the developer runs git commands later (as opposed to npm commands).

Currently, when a project uses commitplease in its default configuration, this means the 'npm ci' or 'npm install' command fails as it can't write to .git/hooks.

Make it easy for these developers to individually disable 'commitplease' (and run the tests manually) by setting an env variable in their container.

For example, as part of their base environment via:

```
export npm_config_commitplease_nohook=1
```

Or ad-hoc, via `npm_config_commitplease_nohook=1 npm ci`.

Fixes https://github.com/jzaefferer/commitplease/issues/111